### PR TITLE
Added dependencies needed for building

### DIFF
--- a/src/seyond_lidar_ros/package.xml
+++ b/src/seyond_lidar_ros/package.xml
@@ -19,7 +19,11 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>message_filters</depend>
-
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
+  <depend>pcl_msgs</depend>
+  <depend>yaml-cpp</depend>
+  
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
Included multiple packages in package.xml (pcl_conversions, pcl_ros, pcl_msgs, yaml-cpp) needed for building the driver, so developers can use rosdep install to fetch all required dependencies.

Tested with:

- ROS1 Noetic
- ROS2 Jazzy