### PR TITLE
make QoS of PointCloud2 publisher overridable via REP-2003 qos_overrides

### DIFF
--- a/src/seyond_lidar_ros/src/driver/ros2_driver_adapter.hpp
+++ b/src/seyond_lidar_ros/src/driver/ros2_driver_adapter.hpp
@@ -72,7 +72,16 @@ class ROSAdapter {
   void init() {
     rclcpp::QoS qos(rclcpp::KeepLast(10));
     qos.reliable();
-    inno_frame_pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(lidar_config_.frame_topic, qos);
+
+    // Expose the frame publisher QoS via REP-2003 "qos_overrides" parameters.
+    // The hardcoded defaults above are kept unless an override is provided.
+    rclcpp::PublisherOptions frame_pub_options;
+    frame_pub_options.qos_overriding_options = rclcpp::QosOverridingOptions(
+        {rclcpp::QosPolicyKind::Reliability, rclcpp::QosPolicyKind::Depth, rclcpp::QosPolicyKind::Deadline,
+         rclcpp::QosPolicyKind::Lifespan, rclcpp::QosPolicyKind::Liveliness,
+         rclcpp::QosPolicyKind::LivelinessLeaseDuration});
+    inno_frame_pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(lidar_config_.frame_topic, qos,
+                                                                                 frame_pub_options);
     driver_ptr_->register_publish_frame_callback(
         std::bind(&ROSAdapter::publishFrame, this, std::placeholders::_1, std::placeholders::_2));
 

--- a/src/seyond_lidar_ros/src/multi_fusion/ros2_multi_fusion.hpp
+++ b/src/seyond_lidar_ros/src/multi_fusion/ros2_multi_fusion.hpp
@@ -94,17 +94,30 @@ MultiFusion::MultiFusion(std::shared_ptr<rclcpp::Node> node_ptr, std::vector<sey
 
   rclcpp::QoS qos(rclcpp::KeepLast(10));
   qos.reliable();
-  fusion_frame_pub_ = node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(common_config.fusion_topic, qos);
+
+  // Expose the fusion publisher and the lidar input subscriptions QoS via REP-2003
+  // "qos_overrides" parameters. The hardcoded defaults are kept unless overridden.
+  const rclcpp::QosOverridingOptions qos_overrides(
+      {rclcpp::QosPolicyKind::Reliability, rclcpp::QosPolicyKind::Depth, rclcpp::QosPolicyKind::Deadline,
+       rclcpp::QosPolicyKind::Lifespan, rclcpp::QosPolicyKind::Liveliness,
+       rclcpp::QosPolicyKind::LivelinessLeaseDuration});
+
+  rclcpp::PublisherOptions pub_options;
+  pub_options.qos_overriding_options = qos_overrides;
+  fusion_frame_pub_ =
+      node_ptr_->create_publisher<sensor_msgs::msg::PointCloud2>(common_config.fusion_topic, qos, pub_options);
 
   if (lidar_num_ < 2 || lidar_num_ > 5) {
     RCLCPP_ERROR(node_ptr_->get_logger(), "Invalid lidar_num: %u", lidar_num_);
     return;
   }
 
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.qos_overriding_options = qos_overrides;
   lidar_subs_.resize(lidar_num_);
   for (uint32_t i = 0; i < lidar_num_; ++i) {
     lidar_subs_[i] = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
-        node_ptr_, lidar_configs[i].frame_topic);
+        node_ptr_, lidar_configs[i].frame_topic, rmw_qos_profile_default, sub_options);
   }
 
   switch (lidar_num_) {


### PR DESCRIPTION
In the current implementation the QoS of the PointCloud2 publisher is hardcoded to be:

- Reliability: reliable
- Depth: 10

These settings in combination which large pointclouds can lead to bottlenecks in the transmissions if a single subscriber is not able to fetch the data in time leading to symptoms reaching from high latency over data bursts to loss of data (for **ALL** subscribers not only the slow subscriber itself!).

ROS2 offers predefined [SensorDataQOS-Natives](https://docs.ros2.org/foxy/api/rclcpp/classrclcpp_1_1SensorDataQoS.html) which are designed for large sensor data. It's in the interest of the itegrator of the seyond_ros_driver to be able to change the QoS to prevent the above bottlenecks.

The changes in the PR make the default QoS of the PointCloud2 Publisher overridable via qos_overrides as per proposal [REP-2003](https://www.ros.org/reps/rep-2003.html). The changes are fully backward compatible since not overriding the QoS will fallback to default QoS Settings as they were before.

The following QoS Settings are exposed:

- `rclcpp::QosPolicyKind::Reliability`
- `rclcpp::QosPolicyKind::Depth`
- `rclcpp::QosPolicyKind::Deadline`
- `rclcpp::QosPolicyKind::Lifespan`
- `rclcpp::QosPolicyKind::Liveliness`
- `rclcpp::QosPolicyKind::LivelinessLeaseDuration`

The following QoS Settings are explicitly **NOT** exposed:

- `rclcpp::QosPolicyKind::History`
- `rclcpp::QosPolicyKind::Durability`

This is because setting History to "keep_all" or Durability to "transient_local" will silently disable the intra-process fast path (`use_intra_process_comms(true)` in `ros2_driver_adapter.hpp`) between the driver internal PointCloud2 Publisher and the (fusion) Subscriber.

Example QoS Overrides in an `qos_overrides.yaml`
```
/**:
  ros__parameters:
    qos_overrides:
      /seyond_1:
        publisher:
          reliability: best_effort
          depth: 5
          lifespan: 300000000   # 300 ms expressed in nanoseconds
        subscription:
          reliability: best_effort
          depth: 5
```

Usage in `launch` args:

--params-file ./qos_overrides.yaml