### PR TITLE
Use relative time offset with uint32 (instead of absolute time offset as double)

### DIFF
--- a/src/seyond_lidar_ros/src/driver/driver_lidar.cc
+++ b/src/seyond_lidar_ros/src/driver/driver_lidar.cc
@@ -570,7 +570,8 @@ void DriverLidar::point_xyz_data_parse(bool is_use_refl, uint32_t point_num, Poi
     point.scan_idx = point_ptr->scan_idx;
     point.flags = point_ptr->channel | roi | (point_ptr->facet << 3);
     point.is_2nd_return = point_ptr->is_2nd_return;
-    point.timestamp = point_ptr->ts_10us / ten_us_in_second_c + current_ts_start_;
+    point.timestamp = static_cast<uint32_t>(
+        ((current_ts_start_ * us_in_second_c - frame_start_ts_) + point_ptr->ts_10us * 10.0) * 1000.0); // point timestamp as offset from frame_start_ts_ in nanoseconds 
 #endif
     coordinate_transfer(&point, param_.coordinate_mode, point_ptr->x, point_ptr->y, point_ptr->z);
     pcl_pc_ptr->points.push_back(point);

--- a/src/seyond_lidar_ros/src/driver/point_types.h
+++ b/src/seyond_lidar_ros/src/driver/point_types.h
@@ -34,7 +34,7 @@ namespace seyond {
 
 struct EIGEN_ALIGN16 PointXYZIT {
   PCL_ADD_POINT4D;
-  double timestamp;
+  std::uint32_t timestamp;
   float intensity;
   std::uint8_t flags;
   std::uint8_t elongation;
@@ -48,7 +48,7 @@ struct EIGEN_ALIGN16 PointXYZIT {
 POINT_CLOUD_REGISTER_POINT_STRUCT(
     seyond::PointXYZIT,
     (float, x, x)(float, y, y)(float, z, z)
-    (double, timestamp, timestamp)
+    (std::uint32_t, timestamp, timestamp)
     (float, intensity, intensity)
     (std::uint8_t, flags, flags)
     (std::uint8_t, elongation, elongation)


### PR DESCRIPTION
Instead of using a double with absolute time, it more often is the practice to store in each point the relative time in nanoseconds to the header time. This has following advantages:

- algorithms like pointcloud deskewing can be directly fetched with relative time between two transformations
- reducing pointcloud size by halving datasize (uint32 instead of double -> a uint32 has a max value value of 4,294,967,295 -> so unit32 can be easily used as there is time for a relative offset in nanoseconds for points of over 4 seconds, which is more than enough for each lidar sensor on the market)

<img width="2547" height="1267" alt="image" src="https://github.com/user-attachments/assets/f33ff80b-78f8-46f9-81de-d4a4ff96c0df" />
